### PR TITLE
Implement CORS and tweak the sinatra error handling

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -36,7 +36,7 @@ configure do
   set :raise_errors, true
   set :show_exceptions, false
 
-  enable :cross_origin
+  enable :cross_origin if Figaro.env.cors_domain
 end
 
 not_found do
@@ -61,7 +61,8 @@ end
 # Sets the response headers
 before do
   content_type 'application/json'
-  response.headers['Access-Control-Allow-Origin'] = '*'
+
+  response.headers['Access-Control-Allow-Origin'] = Figaro.env.cors_domain if Figaro.env.cors_domain
 end
 
 class PamAuth
@@ -107,12 +108,14 @@ before do
   end
 end
 
-options "*" do
-  response.headers["Allow"] = "GET, PUT, POST, DELETE, OPTIONS"
-  response.headers["Access-Control-Allow-Methods"] = "GET, PUT, POST, DELETE, OPTIONS"
-  response.headers["Access-Control-Allow-Headers"] = "Authorization, Content-Type, Accept"
-  status 200
-  ''
+if Figaro.env.cors_domain
+  options "*" do
+    response.headers["Allow"] = "GET, PUT, POST, DELETE, OPTIONS"
+    response.headers["Access-Control-Allow-Methods"] = "GET, PUT, POST, DELETE, OPTIONS"
+    response.headers["Access-Control-Allow-Headers"] = "Authorization, Content-Type, Accept"
+    status 200
+    ''
+  end
 end
 
 namespace '/sessions' do

--- a/app.rb
+++ b/app.rb
@@ -30,9 +30,10 @@
 require 'sinatra'
 require 'sinatra/namespace'
 
-set :show_exceptions, :after_handler
 set :bind, '0.0.0.0'
 set :dump_errors, false
+set :raise_errors, true
+set :show_exceptions, false
 
 configure do
   enable :cross_origin

--- a/app.rb
+++ b/app.rb
@@ -109,6 +109,7 @@ end
 
 options "*" do
   response.headers["Allow"] = "GET, PUT, POST, DELETE, OPTIONS"
+  response.headers["Access-Control-Allow-Methods"] = "GET, PUT, POST, DELETE, OPTIONS"
   response.headers["Access-Control-Allow-Headers"] = "Authorization, Content-Type, Accept"
   status 200
   ''

--- a/app.rb
+++ b/app.rb
@@ -30,13 +30,17 @@
 require 'sinatra'
 require 'sinatra/namespace'
 
-set :bind, '0.0.0.0'
-set :dump_errors, false
-set :raise_errors, true
-set :show_exceptions, false
-
 configure do
+  set :bind, '0.0.0.0'
+  set :dump_errors, false
+  set :raise_errors, true
+  set :show_exceptions, false
+
   enable :cross_origin
+end
+
+not_found do
+  { errors: [NotFound.new] }.to_json
 end
 
 # Converts HttpError objects into their JSON representation. Each object already

--- a/app/system_command.rb
+++ b/app/system_command.rb
@@ -78,7 +78,7 @@ class SystemCommand < Hashie::Dash
   # echo_cache_dir MUST NOT take any inputs. It is executing through a shell and therefore
   # it is possible to preform an injection attack
   def self.echo_cache_dir(user:)
-    Builder.new("bash -c").call('echo ${XDG_CACHE_HOME:-$HOME/.cache}', user: user)
+    Builder.new("ruby -e").call('puts File.join(ENV["HOME"], ".cache")', user: user)
   end
 
   def self.index_sessions(user:)

--- a/config/application.yaml.reference
+++ b/config/application.yaml.reference
@@ -12,6 +12,13 @@
 # =============================================================================
 
 # =============================================================================
+# CORS Domain
+# Enable cross origin resource sharing from the given domain. CORS is disabled
+# by default
+# =============================================================================
+cors_domain:
+
+# =============================================================================
 # Pam Configuration Name
 # Specify which pam configuration file should be used to authenticate requests.
 # It should correlate to a filename stored within /etc/pam.d


### PR DESCRIPTION
CORS can optionally be enabled by setting the `cors_domain` configuration variable. Also minor tweaks have been made to the sinatra error handling