### PR TITLE
Add ping route

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -118,6 +118,13 @@ if Figaro.env.cors_domain
   end
 end
 
+namespace '/ping' do
+  get do
+    status 200
+    'OK'
+  end
+end
+
 namespace '/sessions' do
   helpers do
     def desktop_param


### PR DESCRIPTION
This route can be used to check authorisation details.  This is useful for the client when the user signs in.