### PR TITLE
Correctly handle new lines from sys commands

### DIFF
--- a/app/models.rb
+++ b/app/models.rb
@@ -84,7 +84,7 @@ class Session < Hashie::Trash
 
     def call
       cmd = start
-      if /verified\z/ =~ cmd.stderr
+      if /verified\Z/ =~ cmd.stderr
         verify
         cmd = start
       end

--- a/spec/controllers/sessions_spec.rb
+++ b/spec/controllers/sessions_spec.rb
@@ -425,13 +425,13 @@ RSpec.describe '/sessions' do
 
     let(:unknown_create_stub) do
       SystemCommand.new(
-        code: 1, stdout: '', stderr: "flight desktop: unknown desktop type: #{desktop}"
+        code: 1, stdout: '', stderr: "flight desktop: unknown desktop type: #{desktop}\n"
       )
     end
 
     let(:unverified_create_stub) do
       SystemCommand.new(
-        code: 1, stdout: '', stderr: "flight desktop: Desktop type '#{desktop}' has not been verified"
+        code: 1, stdout: '', stderr: "flight desktop: Desktop type '#{desktop}' has not been verified\n"
       )
     end
 


### PR DESCRIPTION
It makes a difference in the regex matching. The spec has been updated
to reflect the true output from the system commands