### PR TITLE
Do not return JSON data as an array

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -137,7 +137,7 @@ namespace '/sessions' do
   end
 
   get do
-    Session.index(user: current_user).to_json
+    { 'data' => Session.index(user: current_user) }.to_json
   end
 
   post do

--- a/spec/controllers/sessions_spec.rb
+++ b/spec/controllers/sessions_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe '/sessions' do
       end
 
       it 'returns an empty array' do
-        expect(parse_last_response_body).to eq([])
+        expect(parse_last_response_body.data).to eq([])
       end
     end
 
@@ -191,7 +191,7 @@ RSpec.describe '/sessions' do
       end
 
       it 'returns the sessions as JSON' do
-        expect(parse_last_response_body).to eq(sessions.as_json)
+        expect(parse_last_response_body.data).to eq(sessions.as_json)
       end
     end
   end


### PR DESCRIPTION
Their is an obscure CSRF-JSON attack that can be preformed with arrays:
https://haacked.com/archive/2008/11/20/anatomy-of-a-subtle-json-vulnerability.aspx/

The best defence is to always return JSON as a hash not an array