### PR TITLE
Include the desktop summary in the response

### DIFF
--- a/app/models.rb
+++ b/app/models.rb
@@ -156,6 +156,7 @@ class Desktop < Hashie::Trash
 
   property :name
   property :verified, default: false
+  property :summary, default: ''
 
   def to_json
     as_json.to_json
@@ -164,7 +165,8 @@ class Desktop < Hashie::Trash
   def as_json(_ = {})
     {
       'id' => name,
-      'verified' => verified?
+      'verified' => verified?,
+      'summary' => summary
     }
   end
 

--- a/config/initializers/desktop_types.rb
+++ b/config/initializers/desktop_types.rb
@@ -35,8 +35,10 @@ Thread.new do
   loop do
     models = SystemCommand.avail_desktops(user: Figaro.env.USER!)
                           .tap(&:raise_unless_successful)
-                          .stdout.each_line.map { |l| l.split(' ').first }
-                          .map { |n| Desktop.new(name: n) }
+                          .stdout.each_line.map { |l| l.split("\t")[0..1] }
+                          .map do |data|
+      Desktop.new(name: data[0], summary: data[1])
+    end
 
     models.each { |m| m.verify_desktop(user: Figaro.env.USER!) }
     hash = models.map { |m| [m.name, m] }.to_h

--- a/docs/routes.md
+++ b/docs/routes.md
@@ -276,7 +276,8 @@ Accepts: application/json
 HTTP/2 200 OK
 {
   "id": "<UUID>",
-  "verified": <true|false>
+  "verified": <true|false>,
+  "summary": "<summary>"
 }
 ```
 
@@ -293,6 +294,12 @@ Type: String
 Whether the desktop has been checked for the required dependencies. Sessions creation MAY fail for unverified desktops.
 
 Type: Boolean
+
+*summary:*
+
+A short description on the desktop
+
+Type: String
 
 #### Other Responses
 


### PR DESCRIPTION
This is a short description on the desktop type from `flight avail`. Fixes #20 