### PR TITLE
Fix broken sessions and include additional dates when serialising sessions

### DIFF
--- a/app/models.rb
+++ b/app/models.rb
@@ -130,6 +130,13 @@ class Session < Hashie::Trash
                          'metadata.yml')
         File::Stat.new(path).ctime
       end
+      session.last_accessed_at ||= begin
+        path = File.join(session.cache_dir,
+                         'flight/desktop/sessions',
+                         session.id,
+                         'session.log')
+        File::Stat.new(path).ctime if File.exists? path
+      end
     end
   end
 
@@ -146,7 +153,8 @@ class Session < Hashie::Trash
       'port' => webport,
       'password' => password,
       'state' => state,
-      'created_at' => created_at.rfc3339
+      'created_at' => created_at.rfc3339,
+      'last_accessed_at' => last_accessed_at&.rfc3339
     }
   end
 

--- a/app/models.rb
+++ b/app/models.rb
@@ -33,6 +33,7 @@ class Session < Hashie::Trash
   include Hashie::Extensions::Dash::Coercion
 
   def self.index(user:)
+    cache = SystemCommand.echo_cache_dir(user: user)
     cmd = SystemCommand.index_sessions(user: user)
     if cmd.success?
       cmd.stdout.split("\n").map do |line|

--- a/app/models.rb
+++ b/app/models.rb
@@ -36,7 +36,7 @@ class Session < Hashie::Trash
     cmd = SystemCommand.index_sessions(user: user)
     if cmd.success?
       cmd.stdout.split("\n").map do |line|
-        parts = line.squish.split(' ')
+        parts = line.split("\t").map { |p| p.empty? ? nil : p }
         new(
           id: parts[0],
           desktop: parts[1],

--- a/app/models.rb
+++ b/app/models.rb
@@ -33,7 +33,10 @@ class Session < Hashie::Trash
   include Hashie::Extensions::Dash::Coercion
 
   def self.index(user:)
-    cache = SystemCommand.echo_cache_dir(user: user)
+    cache_dir =  SystemCommand.echo_cache_dir(user: user)
+                              .tap(&:raise_unless_successful)
+                              .stdout
+                              .chomp
     cmd = SystemCommand.index_sessions(user: user)
     if cmd.success?
       cmd.stdout.split("\n").map do |line|
@@ -115,6 +118,8 @@ class Session < Hashie::Trash
   property :password
   property :user
   property :state
+  property :created_at, coerce: Time
+  property :last_accessed_at, coerce: Time
 
   def to_json
     as_json.to_json

--- a/app/models.rb
+++ b/app/models.rb
@@ -45,6 +45,7 @@ class Session < Hashie::Trash
           port: parts[5],
           webport: parts[6],
           password: parts[7],
+          state: parts[8],
           user: user
         )
       end
@@ -112,6 +113,7 @@ class Session < Hashie::Trash
   property :webport, coerce: String
   property :password
   property :user
+  property :state
 
   def to_json
     as_json.to_json
@@ -124,7 +126,8 @@ class Session < Hashie::Trash
       'ip' => ip,
       'hostname' => hostname,
       'port' => webport,
-      'password' => password
+      'password' => password,
+      'state' => state
     }
   end
 

--- a/app/models.rb
+++ b/app/models.rb
@@ -129,7 +129,7 @@ class Session < Hashie::Trash
                               .tap(&:raise_unless_successful)
                               .stdout
                               .chomp
-    path = File.join(cache_dir, 'flight/desktop/sessions', id, 'metadata.log')
+    path = File.join(cache_dir, 'flight/desktop/sessions', id, 'metadata.yml')
     self.created_at ||= File::Stat.new(path).ctime
   end
 

--- a/app/system_command.rb
+++ b/app/system_command.rb
@@ -62,6 +62,15 @@ class SystemCommand < Hashie::Dash
     end
   end
 
+  module Handlers
+    def self.load_cache_dir(user:)
+      SystemCommand.echo_cache_dir(user: user)
+                   .tap(&:raise_unless_successful)
+                   .stdout
+                   .chomp
+    end
+  end
+
   # NOTE: This system command is required to determine the cache directory the screenshot
   # is stored within. This is required as it is specific to each user and most be done
   # as a system call.

--- a/config/initializers/desktop_types.rb
+++ b/config/initializers/desktop_types.rb
@@ -32,6 +32,7 @@ return if Figaro.env.RACK_ENV! == 'test'
 
 # Periodically reload and verify the desktops
 Thread.new do
+  count = 0
   loop do
     models = SystemCommand.avail_desktops(user: Figaro.env.USER!)
                           .tap(&:raise_unless_successful)
@@ -44,6 +45,8 @@ Thread.new do
     hash = models.map { |m| [m.name, m] }.to_h
 
     Desktop.instance_variable_set(:@cache, hash)
+    DEFAULT_LOGGER.info "Finished #{'re' if count > 0 }loading the desktops"
+    count += 1
 
     sleep Figaro.env.refresh_rate!.to_i
   end

--- a/docs/routes.md
+++ b/docs/routes.md
@@ -105,7 +105,8 @@ HTTP/2 200 OK
   "ip": "<ip>,
   "hostname": "<hostname>",
   "port": <web-sockify-port>,
-  "password": "<vnc-password>"
+  "password": "<vnc-password>",
+  "state": "<Active|BROKEN|...>"
 }
 ```
 
@@ -141,6 +142,12 @@ The "vnc password" for the session.
 
 Type: String
 
+*state*
+
+The "state" the session is currently in
+
+Type: String
+
 #### Other Responses
 
 ```
@@ -162,7 +169,7 @@ Content-Type: application/json
 
 Start a new vnc session with the given `desktop` type.
 
-*BUG NOTICE*: The `port` is not currently being returned by the request due to internal limitations. Until such time as this bug is fixed, the port SHOULD be determined using a standard `GET Show` request.
+*BUG NOTICE*: The `port` and `state` MAY not be returned by the request due to internal limitations. The `port`/`state` SHOULD be determined using a standard `GET Show` request.
 
 ```
 POST /sessions

--- a/docs/routes.md
+++ b/docs/routes.md
@@ -106,7 +106,9 @@ HTTP/2 200 OK
   "hostname": "<hostname>",
   "port": <web-sockify-port>,
   "password": "<vnc-password>",
-  "state": "<Active|BROKEN|...>"
+  "state": "<Active|BROKEN|...>",
+  "created_at": "<time-rfc339>",
+  "last_accessed_at": "<None|time-rfc3339>"
 }
 ```
 
@@ -147,6 +149,18 @@ Type: String
 The "state" the session is currently in
 
 Type: String
+
+*created_at*
+
+The time the session was created
+
+Type: [RFC3339 Timestamp](https://tools.ietf.org/html/rfc3339)
+
+*last_accessed_at*
+
+The time the session was last accessed. This field MAY be None if the session has not yet be accessed.
+
+Type: None | [RFC3339 Timestamp](https://tools.ietf.org/html/rfc3339)
 
 #### Other Responses
 

--- a/spec/controllers/sessions_spec.rb
+++ b/spec/controllers/sessions_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe '/sessions' do
   def build_session(**opts)
     raise 'missing id' unless opts[:id]
     opts[:created_at] ||= begin
-      path = File.join(cache_dir, 'flight/desktop/sessions', opts[:id], 'metadata.log')
+      path = File.join(cache_dir, 'flight/desktop/sessions', opts[:id], 'metadata.yml')
       FileUtils.mkdir_p(File.dirname(path))
       FileUtils.touch(path)
       File::Stat.new(path).ctime

--- a/spec/controllers/sessions_spec.rb
+++ b/spec/controllers/sessions_spec.rb
@@ -34,6 +34,10 @@ RSpec.describe '/sessions' do
   let(:url_id) { raise NotImplementedError, 'the spec :url_id has not been set' }
   let(:sessions) { raise NotImplementedError, 'the spec has not defined sessions' }
 
+  let(:successful_cache_dir_stub) do
+    SystemCommand.new(stderr: '', code: 0, stdout: "/home/#{username}/.cache\n")
+  end
+
   let(:successful_find_stub) do
     SystemCommand.new(
       stderr: '', code: 0, stdout: <<~STDOUT
@@ -62,6 +66,7 @@ RSpec.describe '/sessions' do
       before do
         # NOTE: "Temporarily" out of use
         # allow(SystemCommand).to receive(:find_session).and_return(exit_213_stub)
+        allow(SystemCommand).to receive(:echo_cache_dir).and_return(successful_cache_dir_stub)
         allow(SystemCommand).to receive(:index_sessions).and_return(exit_213_stub)
         make_request
       end
@@ -108,6 +113,7 @@ RSpec.describe '/sessions' do
       let(:sessions) { [other1, other2] }
 
       before do
+        allow(SystemCommand).to receive(:echo_cache_dir).and_return(successful_cache_dir_stub)
         allow(SystemCommand).to receive(:index_sessions).and_return(index_multiple_stub)
         make_request
       end
@@ -126,6 +132,7 @@ RSpec.describe '/sessions' do
 
     context 'without any running sessions' do
       before do
+        allow(SystemCommand).to receive(:echo_cache_dir).and_return(successful_cache_dir_stub)
         allow(SystemCommand).to receive(:index_sessions).and_return(exit_0_stub)
         make_request
       end
@@ -141,6 +148,7 @@ RSpec.describe '/sessions' do
 
     context 'when the index system command fails' do
       before do
+        allow(SystemCommand).to receive(:echo_cache_dir).and_return(successful_cache_dir_stub)
         allow(SystemCommand).to receive(:index_sessions).and_return(exit_213_stub)
         make_request
       end
@@ -187,6 +195,7 @@ RSpec.describe '/sessions' do
       end
 
       before do
+        allow(SystemCommand).to receive(:echo_cache_dir).and_return(successful_cache_dir_stub)
         allow(SystemCommand).to receive(:index_sessions).and_return(index_multiple_stub)
         make_request
       end
@@ -210,6 +219,7 @@ RSpec.describe '/sessions' do
       let(:id) { '3d17d06e-701a-11ea-a14f-52540005505a' }
 
       before do
+        allow(SystemCommand).to receive(:echo_cache_dir).and_return(successful_cache_dir_stub)
         allow(SystemCommand).to receive(:index_sessions).and_return(broken_index_stub)
         make_request
       end
@@ -280,6 +290,7 @@ RSpec.describe '/sessions' do
       before do
         # NOTE: "Temporarily" out of use
         # allow(SystemCommand).to receive(:find_session).and_return(successful_find_stub)
+        allow(SystemCommand).to receive(:echo_cache_dir).and_return(successful_cache_dir_stub)
         allow(SystemCommand).to receive(:index_sessions).and_return(index_multiple_stub)
         make_request
       end
@@ -313,10 +324,6 @@ RSpec.describe '/sessions' do
     def make_request
       standard_get_headers
       get "/sessions/#{url_id}/screenshot.png"
-    end
-
-    let(:successful_cache_dir_stub) do
-      SystemCommand.new(stderr: '', code: 0, stdout: "/home/#{username}/.cache\n")
     end
 
     include_examples 'sessions error when missing'
@@ -757,6 +764,7 @@ RSpec.describe '/sessions' do
       before do
         # NOTE: "Temporarily" out of use
         # allow(SystemCommand).to receive(:find_session).and_return(successful_find_stub)
+        allow(SystemCommand).to receive(:echo_cache_dir).and_return(successful_cache_dir_stub)
         allow(SystemCommand).to receive(:index_sessions).and_return(index_multiple_stub)
         allow(SystemCommand).to receive(:kill_session).and_return(exit_0_stub)
         make_request
@@ -775,6 +783,7 @@ RSpec.describe '/sessions' do
       before do
         # NOTE: "Temporarily" out of use
         # allow(SystemCommand).to receive(:find_session).and_return(successful_find_stub)
+        allow(SystemCommand).to receive(:echo_cache_dir).and_return(successful_cache_dir_stub)
         allow(SystemCommand).to receive(:index_sessions).and_return(index_multiple_stub)
         allow(SystemCommand).to receive(:kill_session).and_return(exit_213_stub)
         make_request

--- a/spec/controllers/sessions_spec.rb
+++ b/spec/controllers/sessions_spec.rb
@@ -166,9 +166,26 @@ RSpec.describe '/sessions' do
     end
 
     context 'with multiple running sessions' do
+      let(:screenshot_session) do
+        build_session(
+          id: '135c07c2-5c9f-4e32-9372-a408d2bbe621',
+          desktop: 'xfce',
+          hostname: 'example.com',
+          ip: '10.101.0.3',
+          port: 5903,
+          webport: 41303,
+          password: '5wroliv5',
+          state: 'Active'
+        ).tap do |sesh|
+          path = File.join(cache_dir, 'flight/desktop/sessions', sesh.id, 'session.log')
+          FileUtils.touch path
+          sesh.last_accessed_at = File::Stat.new(path).ctime
+        end
+      end
+
       let(:sessions) do
         [
-          {
+          build_session(
             id: '0362d58b-f29a-4b99-9a0a-277c902daa55',
             desktop: 'gnome',
             hostname: 'example.com',
@@ -177,8 +194,8 @@ RSpec.describe '/sessions' do
             webport: 41301,
             password: 'GovCosh6',
             state: 'Active'
-          },
-          {
+          ),
+          build_session(
             id: '135036a4-0471-4014-ab56-7b65648895df',
             desktop: 'kde',
             hostname: 'example.com',
@@ -187,18 +204,9 @@ RSpec.describe '/sessions' do
             webport: 41302,
             password: 'Dinzeph3',
             state: 'Active'
-          },
-          {
-            id: '135c07c2-5c9f-4e32-9372-a408d2bbe621',
-            desktop: 'xfce',
-            hostname: 'example.com',
-            ip: '10.101.0.3',
-            port: 5903,
-            webport: 41303,
-            password: '5wroliv5',
-            state: 'Active'
-          }
-        ].map { |h| build_session(**h) }
+          ),
+          screenshot_session
+        ]
       end
 
       before do

--- a/spec/controllers/sessions_spec.rb
+++ b/spec/controllers/sessions_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe '/sessions' do
 
   let(:index_multiple_stub) do
     stdout = sessions.each_with_index.map do |s, idx|
-      "#{s.id}\t#{s.desktop}\t#{s.hostname}\t#{s.ip}\t#{idx}\t#{s.port}\t#{s.webport}\t#{s.password}\tActive"
+      "#{s.id}\t#{s.desktop}\t#{s.hostname}\t#{s.ip}\t#{idx}\t#{s.port}\t#{s.webport}\t#{s.password}\t#{s.state}"
     end.join("\n")
     SystemCommand.new(stdout: stdout, stderr: '', code: 0)
   end
@@ -87,7 +87,8 @@ RSpec.describe '/sessions' do
           hostname: 'example.com',
           port: 5923,
           webport: 41401,
-          password: 'b187668d'
+          password: 'b187668d',
+          state: 'Active'
         )
       end
 
@@ -99,7 +100,8 @@ RSpec.describe '/sessions' do
           hostname: 'example.com',
           port: 5924,
           webport: 41402,
-          password: '8b17ba61'
+          password: '8b17ba61',
+          state: 'Active'
         )
       end
 
@@ -158,7 +160,8 @@ RSpec.describe '/sessions' do
             ip: '10.101.0.1',
             port: 5901,
             webport: 41301,
-            password: 'GovCosh6'
+            password: 'GovCosh6',
+            state: 'Active'
           },
           {
             id: '135036a4-0471-4014-ab56-7b65648895df',
@@ -167,7 +170,8 @@ RSpec.describe '/sessions' do
             ip: '10.101.0.2',
             port: 5902,
             webport: 41302,
-            password: 'Dinzeph3'
+            password: 'Dinzeph3',
+            state: 'Active'
           },
           {
             id: '135c07c2-5c9f-4e32-9372-a408d2bbe621',
@@ -176,7 +180,8 @@ RSpec.describe '/sessions' do
             ip: '10.101.0.3',
             port: 5903,
             webport: 41303,
-            password: '5wroliv5'
+            password: '5wroliv5',
+            state: 'Active'
           }
         ].map { |h| Session.new(**h) }
       end
@@ -215,8 +220,8 @@ RSpec.describe '/sessions' do
 
       it 'returns a empty-ish response' do
         data = parse_last_response_body.data.first.reject { |_, v| v.nil? }
-        res_id = data.delete('id')
-        expect(res_id).to eq(id)
+        expect(data.delete('id')).to eq(id)
+        expect(data.delete('state')).to eq('Broken')
         expect(data).to be_empty
       end
     end
@@ -239,7 +244,8 @@ RSpec.describe '/sessions' do
           hostname: 'example.com',
           port: 5956,
           webport: 41304,
-          password: '97InM80d'
+          password: '97InM80d',
+          state: 'Active'
         )
       end
 
@@ -251,7 +257,8 @@ RSpec.describe '/sessions' do
           hostname: 'example.com',
           port: 5957,
           webport: 41305,
-          password: 'df18bb48'
+          password: 'df18bb48',
+          state: 'Active'
         )
       end
 
@@ -263,7 +270,8 @@ RSpec.describe '/sessions' do
           hostname: 'example.com',
           port: 5957,
           webport: 41306,
-          password: 'a8fd740d'
+          password: 'a8fd740d',
+          state: 'Active'
         )
       end
 
@@ -322,7 +330,8 @@ RSpec.describe '/sessions' do
           hostname: 'example.com',
           port: 5942,
           webport: 41307,
-          password: 'b74fbb5d'
+          password: 'b74fbb5d',
+          state: 'Active'
         )
       end
 
@@ -350,7 +359,8 @@ RSpec.describe '/sessions' do
           hostname: 'example.com',
           port: 5942,
           webport: 41308,
-          password: 'b74fbb5d'
+          password: 'b74fbb5d',
+          state: 'Active'
         )
       end
 
@@ -377,7 +387,8 @@ RSpec.describe '/sessions' do
           hostname: 'example.com',
           port: 5944,
           webport: 41309,
-          password: '29d20f04'
+          password: '29d20f04',
+          state: 'Active'
         )
       end
 
@@ -530,7 +541,8 @@ RSpec.describe '/sessions' do
           hostname: 'example.com',
           port: 5905,
           webport: 41310,
-          password: 'WakofEb6'
+          password: 'WakofEb6',
+          state: 'Active'
         )
       end
 
@@ -547,11 +559,11 @@ RSpec.describe '/sessions' do
       end
 
       # NOTE: BUG NOTICE!
-      # The create method does not return the websockify port! This should be fixed TBA
-      # Until then, this spec has been updated to reflect the bug
-      # Revisit as required
+      # The create method does not return the websockify port or the state
       it 'returns the subject as JSON' do
-        expect(parse_last_response_body).to eq(subject.as_json.merge('port' => nil))
+        expect(parse_last_response_body).to eq(
+          subject.as_json.merge('port' => nil, 'state' => nil)
+        )
       end
     end
 
@@ -649,7 +661,8 @@ RSpec.describe '/sessions' do
           hostname: 'example.com',
           port: 5906,
           webport: 41311,
-          password: 'ca77d490'
+          password: 'ca77d490',
+          state: 'Active'
         )
       end
 
@@ -680,7 +693,8 @@ RSpec.describe '/sessions' do
           hostname: 'example.com',
           port: 5906,
           webport: 41311,
-          password: 'ca77d490'
+          password: 'ca77d490',
+          state: 'Active'
         )
       end
 
@@ -701,11 +715,11 @@ RSpec.describe '/sessions' do
       end
 
       # NOTE: BUG NOTICE!
-      # The create method does not return the websockify port! This should be fixed TBA
-      # Until then, this spec has been updated to reflect the bug
-      # Revisit as required
+      # The create method does not return the websockify port or the state
       it 'returns the subject as JSON' do
-        expect(parse_last_response_body).to eq(subject.as_json.merge('port' => nil))
+        expect(parse_last_response_body).to eq(
+          subject.as_json.merge('port' => nil, 'state' => nil)
+        )
       end
 
       it 'sets the desktop as verified' do
@@ -723,7 +737,8 @@ RSpec.describe '/sessions' do
         hostname: 'example.com',
         port: 5906,
         webport: 41312,
-        password: 'a33ff119'
+        password: 'a33ff119',
+        state: 'Active'
       )
     end
 


### PR DESCRIPTION
This PR updates the parsing of the results from `index` to account for "broken" sessions. Their where the columns for broken sessions were being squashed, which in turn broken the parsing. This has now been fixed by splitting on `\t`. Fixes #16 

Along with detecting the broken session, the `state` is now serialised with the response. Fixes #17 

The `created_at` and `last_accessed_at` times are now serialised in the response from the server. This is done by directly interrogating the filesystem. At some point this functionality should be integrated into the CLI. Fixes #18
