### PR TITLE
Allow cleaning exited session without 

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -92,7 +92,7 @@ end
 # Adapted from:
 # https://raw.githubusercontent.com/rack/rack-contrib/master/lib/rack/contrib/post_body_content_type_parser.rb
 before do
-  next if ['GET', 'HEAD', 'OPTIONS', 'DELETE'].include? env['REQUEST_METHOD']
+  next if ['GET', 'HEAD', 'OPTIONS'].include? env['REQUEST_METHOD']
   if env['CONTENT_TYPE'] == 'application/json'
     begin
       io = env['rack.input']
@@ -199,7 +199,14 @@ namespace '/sessions' do
 
     delete do
       status 204
-      current_session.kill(user: current_user)
+      case params.fetch('strategy', 'kill')
+      when 'kill'
+        current_session.kill(user: current_user)
+      when 'clean'
+        current_session.clean(user: current_user)
+      else
+        raise BadRequest.new(detail: "unsupported strategy: #{params['strategy']}")
+      end
     end
   end
 end

--- a/app/models.rb
+++ b/app/models.rb
@@ -173,6 +173,14 @@ class Session < Hashie::Trash
     return true if cmd.success?
     raise InternalServerError.new(details: 'failed to delete the session')
   end
+
+  def clean(user:)
+    if SystemCommand.clean_session(id, user: user).success?
+      true
+    else
+      raise InternalServerError.new(details: 'failed to clean the session')
+    end
+  end
 end
 
 class Desktop < Hashie::Trash


### PR DESCRIPTION
There is a difference between terminating a perfectly good running session and cleaning up a broken session.

In the former, the user would expect that they will potentially suffer data loss as a result of their decision to kill the session.  In the latter, the user would expect that any data loss has already taken place and they will not lose anymore data as a result of cleaning a broken or exited session.

It might be tempting to suggest that non-active sessions should be cleaned up automatically and not appear in the list of sessions. However, doing so could result in sessions "disappearing" without the
user understanding why, or what has happened to them.  Should a session "disappear", we run the risk that the user could blame Flight Desktop Access service, particularly if they have experienced data loss.

It should be clear from this that we want to display non-active sessions in the session listing and allow them to be cleaned without attempting to kill them.

---

This commit adds support for selecting a "deletion strategy" when deleting a session.  The route `DELETE /sessions/:id` now accepts an optional JSON encoded body.  The body should be a JSON object with the key `strategy`.  There are two supported strategies, `kill` and `clean`, defaulting to `kill` if one is not specified. 

The `clean` strategy runs `flight desktop clean` without any attempt to kill the session.

---

### Use case: Informing user when sessions have exited unexpectedly

Bob launches a session through Flight Desktop Access service (FDAS).  He makes use of the session for a period of time, before something breaks within the session itself.

The session exits without Bob ending it. For some reason is not cleaned up properly.

Bob wonders what has happened to his session.  He uses Flight Desktop Access service to view a list of his sessions.

Flight Desktop Access service displays the session has having exited and offers the option to clean it up and remove it from the list of sessions.

Bob understands that his session has exited unexpectedly.  He also understands that Flight Desktop Access service has helped to explain what has happened and is less likely to point the finger of blame at FDAS.  Bob elects to clean his session and FDAS removes it from the list
of sessions.